### PR TITLE
Enhancements about type assetions and namespaces

### DIFF
--- a/tests/Lib/Twig/Extension/AbstractExtensionTest.php
+++ b/tests/Lib/Twig/Extension/AbstractExtensionTest.php
@@ -36,7 +36,7 @@ abstract class AbstractExtensionTest extends TestCase
     public function testGetTokenParsers()
     {
         $tokenParsers = $this->extension->getTokenParsers();
-        $this->assertTrue(is_array($tokenParsers));
+        $this->assertIsArray($tokenParsers);
         foreach ($tokenParsers as $tokenParser) {
             $this->assertTrue($tokenParser instanceof TokenParserInterface);
         }
@@ -45,7 +45,7 @@ abstract class AbstractExtensionTest extends TestCase
     public function testGetNodeVisitors()
     {
         $nodeVisitors = $this->extension->getNodeVisitors();
-        $this->assertTrue(is_array($nodeVisitors));
+        $this->assertIsArray($nodeVisitors);
         foreach ($nodeVisitors as $nodeVisitor) {
             $this->assertInstanceOf('Twig_NodeVisitorInterface', $nodeVisitor);
         }
@@ -54,7 +54,7 @@ abstract class AbstractExtensionTest extends TestCase
     public function testGetFilters()
     {
         $filters = $this->extension->getFilters();
-        $this->assertTrue(is_array($filters));
+        $this->assertIsArray($filters);
         foreach ($filters as $filter) {
             $this->assertInstanceOf(TwigFilter::class, $filter);
         }

--- a/tests/View/TwigViewTest.php
+++ b/tests/View/TwigViewTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\TwigView\Test;
+namespace WyriHaximus\TwigView\Test\View;
 
 /**
  * This file is part of TwigView.
@@ -20,6 +20,7 @@ use Twig\Environment;
 use Twig\Error\SyntaxError;
 use WyriHaximus\TwigView\Event\ConstructEvent;
 use WyriHaximus\TwigView\Event\EnvironmentConfigEvent;
+use WyriHaximus\TwigView\Test\TestCase;
 use WyriHaximus\TwigView\View\TwigView;
 
 /**
@@ -38,7 +39,7 @@ class TwigViewTest extends TestCase
 
         $callbackFired = false;
         $eventCallback = function ($event) use (&$callbackFired) {
-            self::assertInstanceof(Environment::class, $event->getSubject()->getTwig());
+            $this->assertInstanceof(Environment::class, $event->getSubject()->getTwig());
             $callbackFired = true;
         };
         EventManager::instance()->on(ConstructEvent::EVENT, $eventCallback);
@@ -88,7 +89,7 @@ class TwigViewTest extends TestCase
         $view->setTwig($twig->reveal());
         $renderedView = $view->render($filename);
 
-        self::assertSame($output, $renderedView);
+        $this->assertSame($output, $renderedView);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Set correct namespaces for ` WyriHaximus\TwigView\Test\View`.
- Using the `assertIsArray` to assert expected type is `array`.
- It's consistency for using `$this` to call assertion methods.