### PR TITLE
Fix deprecation warning in twig loader

### DIFF
--- a/src/Lib/Twig/Loader.php
+++ b/src/Lib/Twig/Loader.php
@@ -110,7 +110,7 @@ class Loader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface, \Twi
      */
     protected function getPaths($plugin)
     {
-        if ($plugin === null || !Plugin::loaded($plugin)) {
+        if ($plugin === null || !Plugin::isLoaded($plugin)) {
             return App::path('Template');
         }
 


### PR DESCRIPTION
When using this package with the latest cakephp 3.x a deprecation warning occurs since `Plugin::loaded($plugin)` should not be used anymore. Instead the explicit method `Plugin::isLoaded($plugin)` should be used. This commit prevents the deprecation notice by using the newly intended method.