### PR TITLE
Fix deprecation and update cakephp to 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ajgl/breakpoint-twig-extension": "^0.3.0",
         "aptoma/twig-markdown": "^2.0",
         "asm89/twig-cache-extension": "^1.0",
-        "cakephp/cakephp": "^3.6",
+        "cakephp/cakephp": "^3.7",
         "jasny/twig-extensions": "^1.0",
         "twig/twig": "^1.27",
         "umpirsky/twig-php-function": "0.1"

--- a/src/Lib/Twig/Loader.php
+++ b/src/Lib/Twig/Loader.php
@@ -110,7 +110,7 @@ class Loader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface, \Twi
      */
     protected function getPaths($plugin)
     {
-        if ($plugin === null || !Plugin::loaded($plugin)) {
+        if ($plugin === null || !Plugin::isLoaded($plugin)) {
             return App::path('Template');
         }
 


### PR DESCRIPTION
This re-adds https://github.com/cakephp/legacy-twig-view/pull/274 and updates cakephp requirement to 3.7.

@ADmad 